### PR TITLE
Failure instead of pending when tasks are incomplete

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = robot => {
       const title = context.payload.pull_request.title;
       const body = context.payload.pull_request.body;
       const isUnChecked = /-\s\[\s\]/g.test(body);
-      const status = isUnChecked ? "pending" : "success";
+      const status = isUnChecked ? "failure" : "success";
 
       robot.log(
         `Updating PR "${title}" (${context.payload.pull_request


### PR DESCRIPTION
Pending status does not block a pull request unless that the branch is marked as protected and the check is marked as required. This might be likely for the main branches, but requires extra effort for side branches.

Pending status also communicates something that needs some waiting, whereas a failure communicates a need for a human to intervene. This might be a difference in personal workflows, but I personally are stumbled by this often.

This is arguably a backwards-incompatible change, so a major version bump can be considered.